### PR TITLE
Upgrade Spring Boot to 2.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.0.RELEASE</version>
+		<version>2.2.1.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>uk.ac.ox.it.lti</groupId>

--- a/src/main/java/uk/ac/ox/it/lti/ltidemo/WebSecurityConfig.java
+++ b/src/main/java/uk/ac/ox/it/lti/ltidemo/WebSecurityConfig.java
@@ -41,7 +41,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     private ToolConsumerService toolConsumerService;
 
     @Override
-    public void configure(WebSecurity webSecurity) {
+    public void configure(WebSecurity webSecurity) throws Exception {
         super.configure(webSecurity);
     }
 


### PR DESCRIPTION
Spring Boot 2.2.1 has been released, verified the demo with this new version.