### PR TITLE
Ensure that our cookie is set post SameSite policy change

### DIFF
--- a/src/main/java/uk/ac/ox/it/lti/ltidemo/TomcatConfiguration.java
+++ b/src/main/java/uk/ac/ox/it/lti/ltidemo/TomcatConfiguration.java
@@ -1,0 +1,25 @@
+package uk.ac.ox.it.lti.ltidemo;
+
+import org.apache.tomcat.util.http.Rfc6265CookieProcessor;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TomcatConfiguration {
+
+    @Bean
+    WebServerFactoryCustomizer<TomcatServletWebServerFactory> cookieProcessorCustomizer() {
+        return tomcatServletWebServerFactory -> tomcatServletWebServerFactory.addContextCustomizers(context -> {
+            /*
+             * This is needed to force our cookies to opt out of the SameSite protection as we set a cookie on a cross
+             * origin POST request. This does cause old browsers (Safari iOS12) to reject our cookie and a more complex
+             * fix is needed if you wish to support them.
+             */
+            Rfc6265CookieProcessor processor = new Rfc6265CookieProcessor();
+            processor.setSameSiteCookies("None");
+            context.setCookieProcessor(processor);
+        });
+    }
+}


### PR DESCRIPTION
https://www.chromestatus.com/feature/5088147346030592 Will mean that cookies will be treated as SameSite lax by default which doesn’t work for an embedded iframe launch. This fixes most browser but will cause old versions of Safari (iOS/macOS) to reject the cookie.