### PR TITLE
Upgrade Spring Boot to 2.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.3.RELEASE</version>
+		<version>2.2.4.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>uk.ac.ox.it.lti</groupId>


### PR DESCRIPTION
Spring Boot 2.2.4 was released:

https://spring.io/blog/2020/01/20/spring-boot-2-2-4-released